### PR TITLE
fix return data （値を戻してなかったので修正)

### DIFF
--- a/src/es6/components/user/history.js
+++ b/src/es6/components/user/history.js
@@ -36,7 +36,11 @@ export default class EmojidexUserHistory {
 
       return this.EC.Data.history(this._history);
     }).then(() => {
-      if (typeof callback === 'function') { callback(this._history); }
+      if (typeof callback === 'function') {
+        callback(this._history);
+      } else {
+        return this._history;
+      }
     });
   }
 


### PR DESCRIPTION
## 何でこの変更が必要なの？
<!-- [必須] この変更が必要な理由を、分り易く書いて下さい -->
History.get().then() をやった時にデータが返ってこなくてパレットのヒストリータブが動かないので、データを返すようにした。

## このPRでやった事は何？
<!-- [必須] リストを使った箇条書きで書いて下さい -->
- then()の中にreturnを追加した

## このPRで確認した事は何？
<!-- [必須] 下記以外に何か確認した事があれば追記して下さい -->
- [x] specがオールグリーン
- [x] パレットのヒストリータブが動作する事

<!-- メモ: コメントに[必須]が無い項目は、特記する事が無ければ消しちゃってOKです 👍 -->
