### PR TITLE
fix favorite get

### DIFF
--- a/src/es6/components/user/favorites.js
+++ b/src/es6/components/user/favorites.js
@@ -23,18 +23,22 @@ export default class EmojidexUserFavorites {
         limit: this.EC.limit,
         detailed: this.EC.detailed,
         auth_token: this.EC.User.auth_info.token
-      },
-      success: response => {
-        this._favorites = response.emoji;
-        this.meta = response.meta;
-        this.cur_page = response.meta.page;
-        this.max_page = Math.ceil(response.total_count / this.EC.limit);
-        this.EC.Data.favorites(response.emoji).then(data => {
-          if (typeof callback === 'function') { callback(this._favorites); }
-        });
       }
     };
-    return this._favoritesAPI(options);
+    return this._favoritesAPI(options).then((response) => {
+      this._favorites = response.emoji;
+      this.meta = response.meta;
+      this.cur_page = response.meta.page;
+      this.max_page = Math.ceil(response.total_count / this.EC.limit);
+
+      return this.EC.Data.favorites(this._favorites);
+    }).then(() => {
+      if (typeof callback === 'function') {
+        callback(this._favorites);
+      } else {
+        return this._favorites;
+      }
+    });
   }
 
   set(emoji_code) {


### PR DESCRIPTION
## 何でこの変更が必要なの？
<!-- [必須] この変更が必要な理由を、詳細を分り易く書いて下さい -->
historyのgetと挙動が異なり、パレットなど使いたい時に微妙に使い方が変わってくるため、混乱したりバグの原因になったりするおそれがあったので、historyのやり方と揃えるようにした。

## このPRでやった事は何？
<!-- [必須] リストを使った箇条書きで書いて下さい -->
- favoriteのgetをプロミスでもコールバックでも動くように修正をした

## このPRで確認した事は何？
<!-- [必須] 下記以外に何か確認した事があれば追記して下さい -->
- [x] specがオールグリーン
- [x] パレットのhistoryタブ、favoriteタブでそれぞれgetする時に同じ書き方で動作すること

## 関連リンクはある？
ed41a382b89e71f4e9f86fd5033bf82a3a3e2b3d