### PR TITLE
delete setAuth, fix spec

### DIFF
--- a/spec/helpers/method.js
+++ b/spec/helpers/method.js
@@ -83,7 +83,7 @@ let getFacesEmoji = chains_data =>
   });
 
 let setPremiumUser = function(chains_data) {
-  this.EC_spec.User.setAuth(premium_user_info.auth_user, premium_user_info.auth_token).then(() => {
+  this.EC_spec.User.login({authtype: 'token', username: premium_user_info.auth_user, auth_token: premium_user_info.auth_token}).then(() => {
     helperChains(chains_data);
   });
 };

--- a/spec/user.spec.js
+++ b/spec/user.spec.js
@@ -143,7 +143,7 @@ describe('EmojidexUser', function() {
           expect(history.length).toBeTruthy();
           done();
         })
-      }, 2000);
+      }, 5000);
     });
 
     describe('History pages [require premium user]', function() {

--- a/src/es6/components/user.js
+++ b/src/es6/components/user.js
@@ -27,6 +27,7 @@ export default class EmojidexUser {
   // 1. {authtype: 'plain', username: 'username', password: '****'}
   // 2. {authtype: 'token', username: 'username', auth_token: '****'}
   // 3. {authtype: 'basic', user: 'username-or-email', password: '****'}
+  // 4. {authtype: 'session'} return auth_info in localstorage.
   // * if no hash is given auto login is attempted
   login(params) {
     switch (params.authtype) {
@@ -114,23 +115,6 @@ export default class EmojidexUser {
       }
     },
       callback);
-  }
-
-  // directly set auth credentials
-  setAuth(user, token, r18 = false, premium = false, premium_exp = null, pro = false, pro_exp = null) {
-    return this.EC.Data.auth_info({
-      status: 'verified',
-      user,
-      token,
-      r18,
-      premium,
-      premium_exp,
-      pro,
-      pro_exp
-    }).then(data => {
-      this.syncUserData();
-      return data;
-    });
   }
 
   // sets auth parameters from a successful auth request [login]


### PR DESCRIPTION
## 何でこの変更が必要なの？
ログインをする時にsetAuthを使用するとtokenが更新されるだけで他のユーザーデータが更新されなくてバグの原因になったため、ログイン方法を修正しようとした。
しかしsetAuthの後にログインしてデータを更新しようとするとtokenLoginと変わらないので、今後はtokenLoginを使用するようにし、setAuthを削除するだけにとどめた。
ローカルストレージでログインに関してはsessionLoginがあるので、それを使用するようにする。

## このPRでやった事は何？
- setAuthメソッドを削除
- setAuthメソッドを使用していた部分をtokenLoginに変更
- specが失敗することが多かったので応急処置としてタイマーを長く設定（historyのgetを修正する時に戻す）

## このPRでやらない事はある？
- historyのgetの修正

## このPRで確認した事は何？
- [x] specがオールグリーン

## 何か伝達事項はある？
- historyのgetが現在はhistoryとhistory/emojiの取得をやっているため遅く、specが失敗することがある。修正すれば解決するものと思われる
- 「Uncaught (in promise) TypeError: Cannot read property 'then' of undefined」が出ることがあるが、上記の影響を受けていると思われるので、修正後に様子を見たい