### PR TITLE
Fix history get

### DIFF
--- a/spec/emoji.spec.js
+++ b/spec/emoji.spec.js
@@ -7,12 +7,14 @@ describe('EmojidexEmoji', function() {
   );
 
   describe('check update', function() {
-    it('need update', done =>
-      EC_spec.Data.storage.update('emojidex.seedUpdated', new Date('1/1/2016').toString()).then(() => {
-        expect(EC_spec.Emoji.checkUpdate()).toBe(true);
-        done();
-      })
-    );
+    it('need update', done => {
+      setTimeout(() => {  // userDataSyncが終わっていないことがあるため
+        EC_spec.Data.storage.update('emojidex.seedUpdated', new Date('1/1/2016').toString()).then(() => {
+          expect(EC_spec.Emoji.checkUpdate()).toBe(true);
+          done();
+        });
+      }, 1000);
+    });
 
     it('unnecessary update', done =>
       EC_spec.Data.storage.update('emojidex.seedUpdated', new Date().toString()).then(() => {

--- a/spec/user.spec.js
+++ b/spec/user.spec.js
@@ -92,22 +92,17 @@ describe('EmojidexUser', function() {
         })
       );
 
-      it('next', done => {
+      it('next/prev', done => {
         EC_spec.limit = 5;
-        EC_spec.User.Favorites.next(favorites => {
-          expect(EC_spec.User.Favorites.cur_page).toEqual(2);
-          done();
-        });
-      });
-
-      it('prev', done => {
-        EC_spec.limit = 5;
-        EC_spec.User.Favorites.next(favorites => {
-          EC_spec.User.Favorites.prev(favorites => {
-            expect(EC_spec.User.Favorites.cur_page).toEqual(1);
-            done();
+        setTimeout(() => {  // Favorites.sync()が終わっていない時があるので
+          EC_spec.User.Favorites.next(favorites => {
+            expect(EC_spec.User.Favorites.cur_page).toEqual(2);
+            EC_spec.User.Favorites.prev(favorites => {
+              expect(EC_spec.User.Favorites.cur_page).toEqual(1);
+              done();
+            });
           });
-        });
+        }, 2000);
       });
     });
   });
@@ -137,13 +132,22 @@ describe('EmojidexUser', function() {
       })
     );
 
+    it('get (history info only)', done =>
+      EC_spec.User.History.getHistoryInfoOnly(history => {
+        expect(history.length).toBeTruthy();
+        expect(history[0].code).toBeFalsy();
+        expect(history[0].times_used).toBeTruthy();
+        done();
+      })
+    );
+
     it('all', done => {
       setTimeout(() => {  // History.sync()が終わっていない時があるので
         EC_spec.User.History.all(history => {
           expect(history.length).toBeTruthy();
           done();
         })
-      }, 5000);
+      }, 2000);
     });
 
     describe('History pages [require premium user]', function() {
@@ -155,22 +159,17 @@ describe('EmojidexUser', function() {
         })
       );
 
-      it('next', done => {
+      it('next/prev', done => {
         EC_spec.limit = 5;
-        EC_spec.User.History.next(history => {
-          expect(EC_spec.User.History.cur_page).toEqual(2);
-          done();
-        });
-      });
-
-      it('prev', done => {
-        EC_spec.limit = 5;
-        EC_spec.User.History.next(history => {
-          EC_spec.User.History.prev(history => {
-            expect(EC_spec.User.History.cur_page).toEqual(1);
-            done();
+        setTimeout(() => {  // History.sync()が終わっていない時があるので
+          EC_spec.User.History.next(history => {
+            expect(EC_spec.User.History.cur_page).toEqual(2);
+            EC_spec.User.History.prev(history => {
+              expect(EC_spec.User.History.cur_page).toEqual(1);
+              done();
+            });
           });
-        });
+        }, 2000);
       });
     });
   });

--- a/src/es6/components/user/history.js
+++ b/src/es6/components/user/history.js
@@ -23,13 +23,11 @@ export default class EmojidexUserHistory {
         limit: this.EC.limit,
         detailed: this.EC.detailed,
         auth_token: this.EC.User.auth_info.token
-      }
+      },
+      url: this.EC.api_url + 'users/history/emoji'
     };
     return this._historyAPI(options).then((response) => {
-      this._history = response.history;
-      return this.getWithEmojiInfo(callback, page);
-    }).then((response) => {
-      $.extend(true, this._history, response.emoji);
+      this._history = response.emoji;
       this.meta = response.meta;
       this.cur_page = response.meta.page;
       this.max_page = Math.ceil(response.total_count / this.EC.limit);
@@ -44,17 +42,27 @@ export default class EmojidexUserHistory {
     });
   }
 
-  getWithEmojiInfo(callback, page = 1) {
+  getHistoryInfoOnly(callback, page = 1) {
     let options = {
       data: {
         page: page,
         limit: this.EC.limit,
         detailed: this.EC.detailed,
         auth_token: this.EC.User.auth_info.token
-      },
-      url: this.EC.api_url + 'users/history/emoji'
+      }
     };
-    return this._historyAPI(options);
+    return this._historyAPI(options).then((response) => {
+      this._history_info = response.history;
+      this.history_info_meta = response.meta;
+      this.history_info_cur_page = response.meta.page;
+      this.history_info_max_page = Math.ceil(response.total_count / this.EC.limit);
+
+      if (typeof callback === 'function') {
+        callback(this._history_info);
+      } else {
+        return this._history_info;
+      }
+    });
   }
 
   set(emoji_code) {


### PR DESCRIPTION
## 何でこの変更が必要なの？
API側が修正されたため。

## このPRでやった事は何？
- users/history/emojiをgetで取得するよう修正
- users/hostoryをgetHistoryInfoOnlyで取得するよう修正
- specの追加
- prevとnextのspecを一つにまとめた
- ログイン処理が終わる前にテストが始まってエラーが出るため、setTimuoutをいれた

## このPRではやらない事にした変更ってあった？
- ログイン時の処理の根本的な修正

## このPRで確認した事は何？
- [ x ] specがオールグリーン